### PR TITLE
add support for -r none

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ Roller provides a pythonic Kernel object for configuring and compiling kernels, 
     * -n, --new-revision: set new revision to create
         * "next" will automatically increment to the next revision
         * Omit this to build directly from the selected config without modification
-    * -c, --config: kernel version to get the initial configuration from. (defaults to current running version)
-    * -r, --config-revision: kernel revision to use for initial configuration. (defaults to "current", which uses /proc/config.gz)
+    * -c, --config: kernel version to get the initial configuration from (defaults to current running version)
+    * -r, --config-revision: kernel revision to use for initial configuration
+        * "current", which is the default, will use /proc/config.gz
+        * "none" will base configuration on `make allnoconfig` rather than using current or a saved config file
     * -s, --skip-install: don't install kernel to /boot
     * -p, --patch: Open a shell before configuration to allow patching the kernel tree
     * -b, --build-dir: Set path to use for downloading/extracting kernel (defaults to /tmp)

--- a/roller.py
+++ b/roller.py
@@ -325,7 +325,11 @@ class Kernel(object):
             subprocess.call(['make', 'mrproper'], stdout=devnull())
         except:
             raise EnvironmentError('Failed to clean your kernel tree')
-        if self.config_revision == 'current':
+        if self.config_revision == 'none':
+            self.log('Using allnoconfig for initial configuration')
+            subprocess.call(['make', 'allnoconfig'])
+            return
+        elif self.config_revision == 'current':
             self.log('Inserting config from current system kernel')
             with gzip.open('/proc/config.gz') as old_config:
                 with open('.config', 'wb') as new_config:


### PR DESCRIPTION
This should resolve #25, by allowing "-r none" to skip using the current or saved config file and instead base the configuration on `make allnoconfig`
